### PR TITLE
I would completely rely on Embed.ly if it's configured

### DIFF
--- a/lib/oembed.js
+++ b/lib/oembed.js
@@ -239,13 +239,7 @@ function applyParameters(url, parameters) {
 exports.fetch = function(url, parameters, cb) {
     exports.discover(url, function(error, alternates) {
 	var oembedUrl;
-	if (alternates && alternates[MIME_OEMBED_JSON]) {
-	    oembedUrl = applyParameters(alternates[MIME_OEMBED_JSON], parameters);
-	    exports.fetchJSON(oembedUrl, cb);
-	} else if (alternates && alternates[MIME_OEMBED_XML]) {
-	    oembedUrl = applyParameters(alternates[MIME_OEMBED_XML], parameters);
-	    exports.fetchXML(oembedUrl, cb);
-	} else if (exports.EMBEDLY_KEY) {
+	if (exports.EMBEDLY_KEY) {
 	    if (!parameters)
 		parameters = {};
 	    /* Fallback to the Embedly oEmbed API */
@@ -257,6 +251,12 @@ exports.fetch = function(url, parameters, cb) {
 
 	    oembedUrl = applyParameters(exports.EMBEDLY_URL, parameters);
 	    exports.fetchJSON(oembedUrl, cb);
+	} else if (alternates && alternates[MIME_OEMBED_JSON]) {
+	    oembedUrl = applyParameters(alternates[MIME_OEMBED_JSON], parameters);
+	    exports.fetchJSON(oembedUrl, cb);
+	} else if (alternates && alternates[MIME_OEMBED_XML]) {
+	    oembedUrl = applyParameters(alternates[MIME_OEMBED_XML], parameters);
+	    exports.fetchXML(oembedUrl, cb);
 	} else
 	    cb(error || new Error("No oEmbed links discovered"));
     });

--- a/lib/oembed.js
+++ b/lib/oembed.js
@@ -112,7 +112,7 @@ DiscoveryHandler.prototype = {
 	var type = attrs && expandEntities(attrs.type);
 	var href = attrs && expandEntities(attrs.href);
 	if (el.name === 'link' &&
-	    attrs.rel === 'alternate' &&
+	    attrs && attrs.rel === 'alternate' &&
 	    type && href) {
 	    this.disco.addAlternate(type, href);
 	}


### PR DESCRIPTION
WordPress has some issues with "for" parameter encoded in final URL fo some reason. 
So the request looks like this: http://public-api.wordpress.com/oembed/1.0/?format=json&url=http%3A%2F%2Frodp.wordpress.com%2F2013%2F02%2F27%2Fon-scorpions-and-frogs%2F&amp;for=wpcom-auto-discovery
But the last "for" parameter should be a part of API URL, not as part of blog post URL, otherwise WP returns 501. Embed.ly handles this flawlessly at least..
