### PR TITLE
migrate deprecated util.pump to readableStream.pipe.

### DIFF
--- a/lib/oembed.js
+++ b/lib/oembed.js
@@ -138,7 +138,7 @@ exports.discover = function(url, cb) {
 	    var disco = new Discovery(function(href) {
 		return resolveUrl(url, href);
 	    }, cb);
-	    util.pump(res, disco);
+	    res.pipe(disco);
 	} else
 	    cb(new Error("HTTP status " + res.statusCode));
     });
@@ -183,7 +183,7 @@ exports.fetchXML = function(url, cb) {
     req.on('response', function(res) {
 	if (res.statusCode === 200) {
 	    var parser = new OEmbedXMLParser(cb);
-	    util.pump(res, parser);
+	    res.pipe(parser);
 	} else
 	    cb(new Error("HTTP status " + res.statusCode));
     });


### PR DESCRIPTION
 Stops annoying warning on the console
