### PR TITLE
#7 - Soundcloud uses text/json+oembed

### DIFF
--- a/lib/oembed.js
+++ b/lib/oembed.js
@@ -61,7 +61,7 @@ exports.USER_AGENT = "node-oembed/" + package.version + " (" + package.homepage 
 
 /**
  * Write stream that collects <link rel='alternate'> @href by @type
- * 
+ *
  * @param {Function} urlConvert Expands relative to absolute URL
  * @param {Function} cb Final callback
  */
@@ -94,7 +94,7 @@ Discovery.prototype.onDone = function() {
 
 /**
  * Methods implement htmlparser handler interface
- * 
+ *
  * @param {Discovery} disco
  */
 function DiscoveryHandler(disco) {
@@ -208,6 +208,7 @@ exports.fetchJSON = function(url, cb) {
 };
 
 var MIME_OEMBED_JSON = exports.MIME_OEMBED_JSON = 'application/json+oembed';
+var MIME_OEMBED_TEXT_JSON = exports.MIME_OEMBED_TEXT_JSON = 'text/json+oembed';
 var MIME_OEMBED_XML = exports.MIME_OEMBED_XML = 'text/xml+oembed';
 var ALLOWED_PARAMETERS = ["url", "format", "key", "maxwidth", "maxheight"];
 
@@ -241,6 +242,9 @@ exports.fetch = function(url, parameters, cb) {
 	var oembedUrl;
 	if (alternates && alternates[MIME_OEMBED_JSON]) {
 	    oembedUrl = applyParameters(alternates[MIME_OEMBED_JSON], parameters);
+	    exports.fetchJSON(oembedUrl, cb);
+	} else if (alternates && alternates[MIME_OEMBED_TEXT_JSON]) {
+	    oembedUrl = applyParameters(alternates[MIME_OEMBED_TEXT_JSON], parameters);
 	    exports.fetchJSON(oembedUrl, cb);
 	} else if (alternates && alternates[MIME_OEMBED_XML]) {
 	    oembedUrl = applyParameters(alternates[MIME_OEMBED_XML], parameters);


### PR DESCRIPTION
This allows you to use the JSON data feed for those websites that wrongly use text/json+oembed (such as soundcloud)
